### PR TITLE
ci: force add docs directory in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs
+          git add -f docs
           # Check if there are any changes to commit
           if git diff --staged --quiet; then
             echo "No changes to deploy."


### PR DESCRIPTION
force add docs to commit step so gh pages deployment works